### PR TITLE
Set plugin to use Python 3, Rhythmbox doesn't work with Python 2 anymore

### DIFF
--- a/tray_icon.plugin
+++ b/tray_icon.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=tray_icon
 IAge=2
 Name=Tray Icon


### PR DESCRIPTION
Sorry, I forgot to change the loader to be used. The plugin won't work without changing this.
