### PR TITLE
Fix playpause button for rhythmbox v3.4

### DIFF
--- a/tray_icon.py
+++ b/tray_icon.py
@@ -183,7 +183,7 @@ class TrayIcon(GObject.Object, Peas.Activatable):
         """
         Starts playing
         """
-        self.player.playpause(True) # does nothing argument
+        self.player.playpause() # does nothing argument
 
     def next(self, widget):
         """


### PR DESCRIPTION
Fix error:
```
Traceback (most recent call last):
  File "/home/itan/.local/share/rhythmbox/plugins/tray_icon.py", line 186, in play
    self.player.playpause(True) # does nothing argument
TypeError: RB.ShellPlayer.playpause() takes exactly 1 argument (2 given)
```

According to [spec](https://wiki.gnome.org/Apps/Rhythmbox/Plugins/WritingGuide#Controlling_Playback) we don't need to pass additional arguments to `shell.props.shell_player.playpause()` method.